### PR TITLE
[share] Allowing shared images on iOS to have specific actions (save …

### DIFF
--- a/packages/share/ios/Classes/FLTSharePlugin.m
+++ b/packages/share/ios/Classes/FLTSharePlugin.m
@@ -194,7 +194,21 @@ static NSString *const PLATFORM_CHANNEL = @"plugins.flutter.io/share";
   }
 
   for (int i = 0; i < [paths count]; i++) {
-    [items addObject:[[ShareData alloc] initWithFile:paths[i] mimeType:mimeTypes[i]]];
+      NSString *path = paths[i];
+      NSString *pathExtension = [path pathExtension];
+      NSString *mimeType = mimeTypes[i];
+      if([pathExtension.lowercaseString isEqualToString:@"jpg"] || 
+         [pathExtension.lowercaseString isEqualToString:@"jpeg"] || 
+         [pathExtension.lowercaseString isEqualToString:@"png"] || 
+         [mimeType.lowercaseString isEqualToString:@"image/jpg"]|| 
+         [mimeType.lowercaseString isEqualToString:@"image/jpeg"]|| 
+         [mimeType.lowercaseString isEqualToString:@"image/png"]) {
+          UIImage *image = [UIImage imageWithContentsOfFile:path];
+          [items addObject:image];
+      }
+      else {
+          [items addObject:[[ShareData alloc] initWithFile:path mimeType:mimeType]];
+      }
   }
 
   [self share:items withController:controller atSource:origin];


### PR DESCRIPTION
## Description

When sharing an image from an iOS app, there are more options available.

![image](https://user-images.githubusercontent.com/7687231/80059253-da40f700-852b-11ea-9195-d8242f04800b.png)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.
