### PR TITLE
[share] Use a customer Provider to avoid name conflicts with other plugins

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -49,3 +49,4 @@ Luigi Agosti <luigi@tengio.com>
 Quentin Le Guennec <quentin@tengio.com>
 Koushik Ravikumar <koushik@tengio.com>
 Nissim Dsilva <nissim@tengio.com>
+Colin Stewart <cms103@gmail.com>

--- a/packages/share/android/src/main/AndroidManifest.xml
+++ b/packages/share/android/src/main/AndroidManifest.xml
@@ -10,7 +10,8 @@
         tools:replace="android:authorities">
         <meta-data
           android:name="android.support.FILE_PROVIDER_PATHS"
-          android:resource="@xml/flutter_share_file_paths" />
+          android:resource="@xml/flutter_share_file_paths"
+          tools:replace="android:resource"/>
       </provider>
     </application>
 </manifest>

--- a/packages/share/android/src/main/AndroidManifest.xml
+++ b/packages/share/android/src/main/AndroidManifest.xml
@@ -5,7 +5,8 @@
         android:name="androidx.core.content.FileProvider"
         android:authorities="${applicationId}.flutter.share_provider"
         android:exported="false"
-        android:grantUriPermissions="true">
+        android:grantUriPermissions="true"
+        tools:replace="android:authorities">
         <meta-data
           android:name="android.support.FILE_PROVIDER_PATHS"
           android:resource="@xml/flutter_share_file_paths" />

--- a/packages/share/android/src/main/AndroidManifest.xml
+++ b/packages/share/android/src/main/AndroidManifest.xml
@@ -1,17 +1,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="io.flutter.plugins.share"
-  xmlns:tools="http://schemas.android.com/tools">
+  package="io.flutter.plugins.share">
     <application>
       <provider
         android:name="io.flutter.plugins.share.ShareFileProvider"
         android:authorities="${applicationId}.flutter.share_provider"
         android:exported="false"
-        android:grantUriPermissions="true"
-        tools:replace="android:authorities">
+        android:grantUriPermissions="true">
         <meta-data
           android:name="android.support.FILE_PROVIDER_PATHS"
-          android:resource="@xml/flutter_share_file_paths"
-          tools:replace="android:resource"/>
+          android:resource="@xml/flutter_share_file_paths"/>
       </provider>
     </application>
 </manifest>

--- a/packages/share/android/src/main/AndroidManifest.xml
+++ b/packages/share/android/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="io.flutter.plugins.share">
+  package="io.flutter.plugins.share"
+  xmlns:tools="http://schemas.android.com/tools">
     <application>
       <provider
         android:name="androidx.core.content.FileProvider"

--- a/packages/share/android/src/main/AndroidManifest.xml
+++ b/packages/share/android/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
   xmlns:tools="http://schemas.android.com/tools">
     <application>
       <provider
-        android:name="androidx.core.content.FileProvider"
+        android:name="io.flutter.plugins.share.ShareFileProvider"
         android:authorities="${applicationId}.flutter.share_provider"
         android:exported="false"
         android:grantUriPermissions="true"

--- a/packages/share/android/src/main/java/io/flutter/plugins/share/ShareFileProvider.java
+++ b/packages/share/android/src/main/java/io/flutter/plugins/share/ShareFileProvider.java
@@ -1,0 +1,14 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.plugins.share;
+
+import androidx.core.content.FileProvider;
+
+/**
+ * Providing a custom {@code FileProvider} prevents manifest {@code <provider>} name collisions.
+ *
+ * <p>See https://developer.android.com/guide/topics/manifest/provider-element.html for details.
+ */
+public class ShareFileProvider extends FileProvider {}


### PR DESCRIPTION
## Description

Using androidx.core.content.FileProvider as the Provider causes conflicts with other plugins that do the same thing.  This change introduces a custom provider "io.flutter.plugins.share.ShareFileProvider" to avoid this issue.

A similar change was made to the image_picker plugin in https://github.com/flutter/plugins/pull/716

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
